### PR TITLE
Add DistributiveOmit utility type

### DIFF
--- a/src/use-workerized-reducer.ts
+++ b/src/use-workerized-reducer.ts
@@ -64,7 +64,7 @@ type UWRMessage<State, Action> =
   | DispatchMessage<State, Action>
   | DestroyMessage<State, Action>;
 
-type DistributiveOmit<T, F extends string | number | symbol> = T extends infer T ? Omit<T, F> : never;
+type DistributiveOmit<T, F extends string | number | symbol> = T extends infer R ? Omit<R, F> : never;
 
 export function initWorkerizedReducer<State, Action, LocalState = {}>(
   reducerName: string,

--- a/src/use-workerized-reducer.ts
+++ b/src/use-workerized-reducer.ts
@@ -59,6 +59,8 @@ interface PatchMessage<State, Action> {
   patches: Patch[];
 }
 
+type OmitUnion<T, F extends string | number | symbol> = T extends any ? Omit<T, F> : never;
+
 type UWRMessage<State, Action> =
   | InitMessage<State, Action>
   | DispatchMessage<State, Action>
@@ -168,9 +170,7 @@ export function useWorkerizedReducer<State, Action>(
     return JSON.stringify([id, reducerName]);
   }
 
-  // FIXME: This type is not correct. It’s any of the UWRMessages,
-  // but without `id` or `name`. Couldn’t get it to work with `Omit` tho.
-  function send(payload: Partial<UWRMessage<State, Action>>) {
+  function send(payload: OmitUnion<UWRMessage<State, Action>, 'id' | 'name'>) {
     const id = uid();
     pendingIds.add(id);
     setBusy(true);

--- a/src/use-workerized-reducer.ts
+++ b/src/use-workerized-reducer.ts
@@ -59,12 +59,12 @@ interface PatchMessage<State, Action> {
   patches: Patch[];
 }
 
-type OmitUnion<T, F extends string | number | symbol> = T extends any ? Omit<T, F> : never;
-
 type UWRMessage<State, Action> =
   | InitMessage<State, Action>
   | DispatchMessage<State, Action>
   | DestroyMessage<State, Action>;
+
+type DistributiveOmit<T, F extends string | number | symbol> = T extends infer T ? Omit<T, F> : never;
 
 export function initWorkerizedReducer<State, Action, LocalState = {}>(
   reducerName: string,
@@ -170,7 +170,7 @@ export function useWorkerizedReducer<State, Action>(
     return JSON.stringify([id, reducerName]);
   }
 
-  function send(payload: OmitUnion<UWRMessage<State, Action>, 'id' | 'name'>) {
+  function send(payload: DistributiveOmit<UWRMessage<State, Action>, 'id' | 'name'>) {
     const id = uid();
     pendingIds.add(id);
     setBusy(true);


### PR DESCRIPTION
I used [Distributive Conditional Types](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types) with [`infer`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#type-inference-in-conditional-types) keyword to avoid using `any` like `T extends any`. But maybe `T extends any` is okay though.